### PR TITLE
fix: types are not exported correctly in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "homepage": "https://github.com/maptiler/maptiler-client-js",
   "exports": {
     "import": "./dist/maptiler-client.mjs",
-    "require": "./dist/maptiler-client.cjs"
+    "require": "./dist/maptiler-client.cjs",
+    "types": "./dist/maptiler-client.d.ts"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
Follow up of https://github.com/maptiler/maptiler-sdk-js/pull/47 to have all the types exported correctly.