### PR TITLE
Go 180 exclude types geocoding parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## DEVEL
 ### New Features
 - synchronized geocoding types with current geocoding API
+- added `excludeTypes` option to geocoding API
 
 ### Bug Fixes
 ### Others

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@maptiler/client",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@maptiler/client",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@rollup/pluginutils": "^5.0.5",

--- a/src/services/geocoding.ts
+++ b/src/services/geocoding.ts
@@ -243,7 +243,7 @@ export type GeocodingSearchResult = {
 
 function addLanguageGeocodingOptions(
   searchParams: URLSearchParams,
-  options: LanguageGeocodingOptions
+  options: LanguageGeocodingOptions,
 ) {
   const { language } = options;
 
@@ -254,9 +254,9 @@ function addLanguageGeocodingOptions(
   const languages = Array.from(
     new Set(
       (Array.isArray(language) ? language : [language]).map((lang) =>
-        lang === LanguageGeocoding.AUTO ? getAutoLanguageGeocoding() : lang
-      )
-    )
+        lang === LanguageGeocoding.AUTO ? getAutoLanguageGeocoding() : lang,
+      ),
+    ),
   ).join(",");
 
   searchParams.set("language", languages);
@@ -264,9 +264,9 @@ function addLanguageGeocodingOptions(
 
 function addCommonForwardAndReverseGeocodingOptions(
   searchParams: URLSearchParams,
-  options: CommonForwardAndReverseGeocodingOptions
+  options: CommonForwardAndReverseGeocodingOptions,
 ) {
-  const { apiKey, limit, types } = options;
+  const { apiKey, limit, types, excludeTypes } = options;
 
   searchParams.set("key", apiKey ?? config.apiKey);
 
@@ -278,12 +278,16 @@ function addCommonForwardAndReverseGeocodingOptions(
     searchParams.set("types", types.join(","));
   }
 
+  if (excludeTypes != undefined) {
+    searchParams.set("excludeTypes", String(excludeTypes));
+  }
+
   addLanguageGeocodingOptions(searchParams, options);
 }
 
 function addForwardGeocodingOptions(
   searchParams: URLSearchParams,
-  options: GeocodingOptions
+  options: GeocodingOptions,
 ) {
   addCommonForwardAndReverseGeocodingOptions(searchParams, options);
 
@@ -296,7 +300,7 @@ function addForwardGeocodingOptions(
   if (proximity != undefined) {
     searchParams.set(
       "proximity",
-      proximity === "ip" ? proximity : proximity.join(",")
+      proximity === "ip" ? proximity : proximity.join(","),
     );
   }
 
@@ -324,7 +328,7 @@ function addForwardGeocodingOptions(
  */
 async function forward(
   query: string,
-  options: GeocodingOptions = {}
+  options: GeocodingOptions = {},
 ): Promise<GeocodingSearchResult> {
   if (typeof query !== "string" || query.trim().length === 0) {
     throw new Error("The query must be a non-empty string");
@@ -332,7 +336,7 @@ async function forward(
 
   const endpoint = new URL(
     `geocoding/${encodeURIComponent(query)}.json`,
-    defaults.maptilerApiURL
+    defaults.maptilerApiURL,
   );
 
   const { searchParams } = endpoint;
@@ -362,7 +366,7 @@ async function forward(
  */
 async function reverse(
   position: Position,
-  options: ReverseGeocodingOptions = {}
+  options: ReverseGeocodingOptions = {},
 ): Promise<GeocodingSearchResult> {
   if (!Array.isArray(position) || position.length < 2) {
     throw new Error("The position must be an array of form [lng, lat].");
@@ -370,7 +374,7 @@ async function reverse(
 
   const endpoint = new URL(
     `geocoding/${position[0]},${position[1]}.json`,
-    defaults.maptilerApiURL
+    defaults.maptilerApiURL,
   );
 
   addCommonForwardAndReverseGeocodingOptions(endpoint.searchParams, options);
@@ -399,7 +403,7 @@ async function reverse(
  */
 async function byId(
   id: string,
-  options: ByIdGeocodingOptions = {}
+  options: ByIdGeocodingOptions = {},
 ): Promise<GeocodingSearchResult> {
   const endpoint = new URL(`geocoding/${id}.json`, defaults.maptilerApiURL);
   endpoint.searchParams.set("key", options.apiKey ?? config.apiKey);
@@ -429,7 +433,7 @@ async function byId(
  */
 async function batch(
   queries: string[],
-  options: GeocodingOptions = {}
+  options: GeocodingOptions = {},
 ): Promise<GeocodingSearchResult[]> {
   if (!queries.length) {
     return [];
@@ -441,7 +445,7 @@ async function batch(
 
   const endpoint = new URL(
     `geocoding/${joinedQuery}.json`,
-    defaults.maptilerApiURL
+    defaults.maptilerApiURL,
   );
 
   const { searchParams } = endpoint;

--- a/src/services/geocoding.ts
+++ b/src/services/geocoding.ts
@@ -35,7 +35,8 @@ export type CommonForwardAndReverseGeocodingOptions =
     limit?: number;
 
     /**
-     * Filter of feature types to return. If not specified, feature of all available types except `poi` are returned.
+     * Filter of feature types to return.
+     * If not specified, feature of all available types except `poi` are returned (`types = ["poi"]`, `excludeTypes = true`).
      */
     types?: (
       | "country"
@@ -53,6 +54,11 @@ export type CommonForwardAndReverseGeocodingOptions =
       | "address"
       | "poi"
     )[];
+
+    /**
+     * Set to `true` to use all available feature types except those mentioned in `types`. Default value is `false` if `types` is specified.
+     */
+    excludeTypes?: boolean;
   };
 
 export type GeocodingOptions = CommonForwardAndReverseGeocodingOptions & {


### PR DESCRIPTION
## Objective
Add `excludeTypes` geocoding parameter

## Description
Added `excludeTypes` geocoding parameter

## Acceptance
Tested manually

## Checklist
- [x] I have added relevant info to the CHANGELOG.md