### PR TITLE
FIX CJS issue due to QuickLRU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 ### Bug Fixes
 ### Others
 
+## 1.8.1
+### Bug Fixes
+- The QuickLRU dependency is not CJS compatible to it is now fully bundled into the CJS bundle
+
+### Others
+- Moved somes wrongly positioned deps into devDep
+
 ## 1.8.0
 ### New Features
 - Rework of the elevation API to be improve developper experience (new module `elevation`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maptiler/client",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Javascript & Typescript wrapper to MapTiler Cloud API",
   "module": "dist/maptiler-client.mjs",
   "types": "dist/maptiler-client.d.ts",
@@ -71,11 +71,11 @@
     "typedoc": "^0.25.2",
     "typedoc-plugin-markdown": "^3.16.0",
     "typescript": "^5.2.2",
-    "vitest": "^0.34.6"
+    "vitest": "^0.34.6",
+    "@rollup/pluginutils": "^5.0.5",
+    "@types/geojson": "^7946.0.10"
   },
   "dependencies": {
-    "@rollup/pluginutils": "^5.0.5",
-    "@types/geojson": "^7946.0.10",
     "quick-lru": "^7.0.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -25,7 +25,7 @@ const bundles = [
     watch: {
       include: "src/**"
     },
-    external: ["web-merc-projection", "quick-lru"]
+    external: ["quick-lru"]
   },
 
   // CJS module, not minified + sourcemap
@@ -48,7 +48,7 @@ const bundles = [
     watch: {
       include: "src/**"
     },
-    external: ["web-merc-projection", "quick-lru"]
+    external: [] // Decided to include QuickLRU to the CJS bundle because it is otherwise not CJS compatible
   },
 
   // UMD module, not minified
@@ -106,7 +106,7 @@ if (process.env.NODE_ENV === "production") {
       }
     ],
     input: "src/index.ts",
-    external: ["web-merc-projection", "quick-lru"],
+    external: ["quick-lru"],
   },
   {
     plugins: [


### PR DESCRIPTION
[RD-213](https://maptiler.atlassian.net/browse/RD-213)

## Objective
Make the client lib work with CommonJS

## Description
So far was not working because the dependency QuickLRU is not CJS compatible. For its CJS target, the client lib now fully integrates QuickLRU into the bundle so that it does not need to be bundled by projects using the client lib.

## Acceptance
The Client lib works on cjs.

Runing `node main.cjs` on the following file:

```js
// main.cjs

const maptilerClient = require("@maptiler/client");
maptilerClient.config.apiKey = "YOUR_API_KEY";

(async () => {
  const result = await maptilerClient.geocoding.forward("Paris, France");
  console.log(JSON.stringify(result, null, 2));
})();
```

## Checklist
- [x] I have added relevant info to the CHANGELOG.md

[RD-213]: https://maptiler.atlassian.net/browse/RD-213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ