### PR TITLE
Fix broken link to docs in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ npm install --save @maptiler/client
 ```
 
 # API documentation
-In addition to the details and examples provided in this readme, check out the [complete API documentation](https://labs.maptiler.com/maptiler-client-js).
+In addition to the details and examples provided in this readme, check out the [complete API documentation](https://docs.maptiler.com/client-js/).
 
 # Quick start
 ```ts


### PR DESCRIPTION
## Objective
The link [complete API documentation](https://labs.maptiler.com/maptiler-client-js) in `readme.md` is not working (404 File not found).

## Description
Replace the link
https://labs.maptiler.com/maptiler-client-js -> https://docs.maptiler.com/client-js/

## Acceptance
https://github.com/maptiler/maptiler-client-js/blob/readme-doc-link/readme.md#api-documentation

## Checklist
- [ ] No relevant info added to the CHANGELOG.md