### PR TITLE
RD-1867 Limit npm package content

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,0 @@
-docs
-docsmd
-images
-test
-src
-examples
-dist/*.umd.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # MapTiler Client Changelog
 
+## NEXT
+
+### Bug Fixes
+- Fixes content of published npm package to contain only necessary files (no change for UMD)
+
 ## 3.0.0
 
 ### ⚠️ Breaking Changes

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     "require": "./dist/maptiler-client.cjs",
     "types": "./dist/maptiler-client.d.ts"
   },
+  "files": [
+    "dist",
+    "!dist/*.umd.*"
+  ],
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
## Objective
Only add files into npm package that are needed for the package to work correctly

## Description
Changed opt-out for opt-in when selecting which files should be included in npm package

Latest release: package size 141.7 kB / unpacked size: 750.8 kB
After fix: package size 134.5 kB / unpacked size 728.5 kB
Saves: 5.1% / 3.0%

## Acceptance
Publish dry run

## Checklist
- [x] I have added relevant info to the CHANGELOG.md