### PR TITLE
IT-2623 Update npm-publish.yml workflow to use Trusted publishing

### DIFF
--- a/.github/workflows/npm-publish-dry-run.yml
+++ b/.github/workflows/npm-publish-dry-run.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.release.target_commitish }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 18
           registry-url: https://registry.npmjs.org/
@@ -40,12 +40,8 @@ jobs:
         if: "!github.event.release.prerelease"
         run: |
           npm publish --dry-run
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
 
       - name: Publish NPM package (pre-release)
         if: "github.event.release.prerelease"
         run: |
           npm publish --tag next --dry-run
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,6 +3,10 @@
 
 name: Node.js Package
 
+permissions:
+  id-token: write  # Required for NPM trusted publishing
+  contents: read
+
 on:
   release:
     types: [created]
@@ -12,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.release.target_commitish }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 18
           registry-url: https://registry.npmjs.org/
@@ -40,18 +44,16 @@ jobs:
         if: "!github.event.release.prerelease"
         run: |
           npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
 
       - name: Publish NPM package (pre-release)
         if: "github.event.release.prerelease"
         run: |
           npm publish --tag next
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+
       - name: Get Package version
         id: version
         run: echo "PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
+        
       - name: Publish to CDN Cloudflar R2
         uses: ryand56/r2-upload-action@v1.4
         with:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.release.target_commitish }}
 
@@ -54,7 +54,7 @@ jobs:
         id: version
         run: echo "PACKAGE_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
         
-      - name: Publish to CDN Cloudflar R2
+      - name: Publish to CDN Cloudflare R2
         uses: ryand56/r2-upload-action@v1.4
         with:
           r2-account-id: ${{ secrets.CDN_MAPTILER_ACCOUNT_ID }}


### PR DESCRIPTION
IT-2623

## Objective
Replace NPM_TOKEN by NPM Trusted publishing, see: https://maptiler.atlassian.net/wiki/spaces/MAPTILER/pages/3761274898/Public+NPM+packages

## Description
Workflow npm-publish.yml updated:
- permissions required for OIDC added
- NPM_TOKEN environment variable removed
- actions version updated

Workflow publish-dry-run.yml updated:
- NPM_TOKEN environment variable removed - NPM authentication not needed for dry run
- actions version updated

GitHub Actions connection to NPMJS registry is already setup.

## Acceptance
ACTION REQUIRED:
Please review, merge and test. In case of any issues, contact Infrastructure team.
NPM_TOKEN will expire Aug 24, 2026, after this date old authentication will no longer work.

## Checklist
- [] I have added relevant info to the CHANGELOG.md - workflow change, not relevant for changelog