### PR TITLE
Readme: Fix elevation link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ The **MapTiler Client JS** exposes a number of handy functions that wrap API cal
 - [Coordinate systems search and transform](#-coordinates)
 - [User data fetching as GeoJSON](#-data)
 - [Static maps of all sorts](#%EF%B8%8F-static-maps)
-- [Elevation lookup with batch features](#-elevation)
+- [Elevation lookup with batch features](#%EF%B8%8F-elevation)
 
 The project is entirely written in TypeScript and all the function arguments are nicely documented and typed.
 


### PR DESCRIPTION
## Objective

The [_Elevation lookup with batch features_](https://github.com/maptiler/maptiler-client-js#-elevation) link in [readme.md](https://github.com/maptiler/maptiler-client-js/blob/main/readme.md) is broken because of the emoji.

## Description

Update the _Elevation lookup with batch features_ link to: https://github.com/maptiler/maptiler-client-js#%EF%B8%8F-elevation

## Acceptance

You can test it here: https://github.com/maptiler/maptiler-client-js/blob/readme-elevation-link/readme.md

Tested with Firefox 155, Edge 152, Edge 153

## Checklist
- [ ] ~~I have added relevant info to the CHANGELOG.md~~